### PR TITLE
Enable testing with ASAN, UBSAN in both DEBUG and RELEASE mode

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -29,6 +29,8 @@ jobs:
         popd
         popd
         popd
+    - name: Bump up stack size to ~16MB
+      run: ulimit -s 16384
     - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
       run: CXX=${{matrix.compiler}} make -j
     - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -30,9 +30,10 @@ jobs:
         popd
         popd
     - name: Bump up stack size to ~64MB
+      if: ${{matrix.os == 'ubuntu-latest'}}
       run: ulimit -s 65536
     - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
-      run: ulimit -s; CXX=${{matrix.compiler}} make -j
+      run: CXX=${{matrix.compiler}} make -j
     - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
       run: CXX=${{matrix.compiler}} make debug_asan_test -j
     - name: Execute Tests with AddressSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -29,10 +29,10 @@ jobs:
         popd
         popd
         popd
-    - name: Bump up stack size to ~32MB
-      run: ulimit -s 32768
+    - name: Bump up stack size to ~64MB
+      run: ulimit -s 65536
     - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
-      run: CXX=${{matrix.compiler}} make -j
+      run: ulimit -s; CXX=${{matrix.compiler}} make -j
     - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
       run: CXX=${{matrix.compiler}} make debug_asan_test -j
     - name: Execute Tests with AddressSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        compiler: [g++, clang++]
 
     steps:
     - uses: actions/checkout@v4
@@ -28,9 +29,13 @@ jobs:
         popd
         popd
         popd
-    - name: Execute Tests on ${{matrix.os}}
-      run: make -j
-    - name: Execute Tests with AddressSanitizer on ${{matrix.os}}
-      run: make asan_test -j
-    - name: Execute Tests with UndefinedBehaviourSanitizer on ${{matrix.os}}
-      run: make ubsan_test -j
+    - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+      run: CXX=${{matrix.compiler}} make -j
+    - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+      run: CXX=${{matrix.compiler}} make debug_asan_test -j
+    - name: Execute Tests with AddressSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+      run: CXX=${{matrix.compiler}} make release_asan_test -j
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+      run: CXX=${{matrix.compiler}} make debug_ubsan_test -j
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+      run: CXX=${{matrix.compiler}} make release_ubsan_test -j

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -29,16 +29,31 @@ jobs:
         popd
         popd
         popd
-    - name: Bump up stack size to ~64MB
-      if: ${{matrix.os == 'ubuntu-latest'}}
-      run: ulimit -s 65536
     - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
       run: CXX=${{matrix.compiler}} make -j
-    - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+
+    - name: Execute Tests with AddressSanitizer, in DEBUG mode, on Ubuntu, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
+      run: ulimit -s 65536 && CXX=${{matrix.compiler}} make debug_asan_test -j
+    - name: Execute Tests with AddressSanitizer, in RELEASE mode, on Ubuntu, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
+      run: ulimit -s 65536 && CXX=${{matrix.compiler}} make release_asan_test -j
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in DEBUG mode, on Ubuntu, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
+      run: ulimit -s 65536 && CXX=${{matrix.compiler}} make debug_ubsan_test -j
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in RELEASE mode, on Ubuntu, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
+      run: ulimit -s 65536 && CXX=${{matrix.compiler}} make release_ubsan_test -j
+
+    - name: Execute Tests with AddressSanitizer, in DEBUG mode, on MacOS, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: CXX=${{matrix.compiler}} make debug_asan_test -j
-    - name: Execute Tests with AddressSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+    - name: Execute Tests with AddressSanitizer, in RELEASE mode, on MacOS, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: CXX=${{matrix.compiler}} make release_asan_test -j
-    - name: Execute Tests with UndefinedBehaviourSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in DEBUG mode, on MacOS, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: CXX=${{matrix.compiler}} make debug_ubsan_test -j
-    - name: Execute Tests with UndefinedBehaviourSanitizer, in RELEASE mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}
+    - name: Execute Tests with UndefinedBehaviourSanitizer, in RELEASE mode, on MacOS, compiled with ${{matrix.compiler}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: CXX=${{matrix.compiler}} make release_ubsan_test -j

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -29,8 +29,8 @@ jobs:
         popd
         popd
         popd
-    - name: Bump up stack size to ~16MB
-      run: ulimit -s 16384
+    - name: Bump up stack size to ~32MB
+      run: ulimit -s 32768
     - name: Execute Tests on ${{matrix.os}}, compiled with ${{matrix.compiler}}
       run: CXX=${{matrix.compiler}} make -j
     - name: Execute Tests with AddressSanitizer, in DEBUG mode, on ${{matrix.os}}, compiled with ${{matrix.compiler}}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 CXX ?= clang++
 CXX_FLAGS = -std=c++20
-WARN_FLAGS = -Wall -Wextra -pedantic
-OPT_FLAGS = -O3 -march=native
+WARN_FLAGS = -Wall -Wextra -Wpedantic
+DEBUG_FLAGS = -O1 -g
+RELEASE_FLAGS = -O3 -march=native
 LINK_FLAGS = -flto
-ASAN_FLAGS = -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address # From https://clang.llvm.org/docs/AddressSanitizer.html
-UBSAN_FLAGS = -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=undefined # From https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+ASAN_FLAGS = -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address # From https://clang.llvm.org/docs/AddressSanitizer.html
+DEBUG_ASAN_FLAGS = $(DEBUG_FLAGS) $(ASAN_FLAGS)
+RELEASE_ASAN_FLAGS = -g $(RELEASE_FLAGS) $(ASAN_FLAGS)
+UBSAN_FLAGS = -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=undefined # From https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+DEBUG_UBSAN_FLAGS = $(DEBUG_FLAGS) $(UBSAN_FLAGS)
+RELEASE_UBSAN_FLAGS = -g $(RELEASE_FLAGS) $(UBSAN_FLAGS)
 
 I_FLAGS = -I ./include
 SHA3_INC_DIR = ./sha3/include
@@ -15,40 +20,59 @@ DEP_IFLAGS = -I $(SHA3_INC_DIR) -I $(ASCON_INC_DIR) -I $(SUBTLE_INC_DIR)
 SRC_DIR = include
 RACCOON_SOURCES := $(shell find $(SRC_DIR) -name '*.hpp')
 BUILD_DIR = build
+TEST_BUILD_DIR = $(BUILD_DIR)/test
+BENCHMARK_BUILD_DIR = $(BUILD_DIR)/benchmark
 ASAN_BUILD_DIR = $(BUILD_DIR)/asan
+DEBUG_ASAN_BUILD_DIR = $(ASAN_BUILD_DIR)/debug
+RELEASE_ASAN_BUILD_DIR = $(ASAN_BUILD_DIR)/release
 UBSAN_BUILD_DIR = $(BUILD_DIR)/ubsan
+DEBUG_UBSAN_BUILD_DIR = $(UBSAN_BUILD_DIR)/debug
+RELEASE_UBSAN_BUILD_DIR = $(UBSAN_BUILD_DIR)/release
 
 TEST_DIR = tests
 TEST_SOURCES := $(wildcard $(TEST_DIR)/*.cpp)
 TEST_HEADERS := $(wildcard $(TEST_DIR)/*.hpp)
-TEST_OBJECTS := $(addprefix $(BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
-ASAN_TEST_OBJECTS := $(addprefix $(ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
-UBSAN_TEST_OBJECTS := $(addprefix $(UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+TEST_OBJECTS := $(addprefix $(TEST_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+TEST_BINARY = $(TEST_BUILD_DIR)/test.out
 TEST_LINK_FLAGS = -lgtest -lgtest_main
-TEST_BINARY = $(BUILD_DIR)/test.out
-ASAN_TEST_BINARY = $(ASAN_BUILD_DIR)/test.out
-UBSAN_TEST_BINARY = $(UBSAN_BUILD_DIR)/test.out
 GTEST_PARALLEL = ./gtest-parallel/gtest-parallel
+DEBUG_ASAN_TEST_OBJECTS := $(addprefix $(DEBUG_ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+RELEASE_ASAN_TEST_OBJECTS := $(addprefix $(RELEASE_ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+DEBUG_ASAN_TEST_BINARY = $(DEBUG_ASAN_BUILD_DIR)/test.out
+RELEASE_ASAN_TEST_BINARY = $(RELEASE_ASAN_BUILD_DIR)/test.out
+DEBUG_UBSAN_TEST_OBJECTS := $(addprefix $(DEBUG_UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+RELEASE_UBSAN_TEST_OBJECTS := $(addprefix $(RELEASE_UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+DEBUG_UBSAN_TEST_BINARY = $(DEBUG_UBSAN_BUILD_DIR)/test.out
+RELEASE_UBSAN_TEST_BINARY = $(RELEASE_UBSAN_BUILD_DIR)/test.out
 
 BENCHMARK_DIR = benchmarks
 BENCHMARK_SOURCES := $(wildcard $(BENCHMARK_DIR)/*.cpp)
 BENCHMARK_HEADERS := $(wildcard $(BENCHMARK_DIR)/*.hpp)
-BENCHMARK_OBJECTS := $(addprefix $(BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(BENCHMARK_SOURCES))))
+BENCHMARK_OBJECTS := $(addprefix $(BENCHMARK_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(BENCHMARK_SOURCES))))
 BENCHMARK_LINK_FLAGS = -lbenchmark -lbenchmark_main -lpthread
-BENCHMARK_BINARY = $(BUILD_DIR)/bench.out
+BENCHMARK_BINARY = $(BENCHMARK_BUILD_DIR)/bench.out
 PERF_LINK_FLAGS = -lbenchmark -lbenchmark_main -lpfm -lpthread
-PERF_BINARY = $(BUILD_DIR)/perf.out
+PERF_BINARY = $(BENCHMARK_BUILD_DIR)/perf.out
 BENCHMARK_OUT_FILE = bench_result_on_$(shell uname -s)_$(shell uname -r)_$(shell uname -m)_with_$(CXX)_$(shell $(CXX) -dumpversion).json
 
 all: test
 
-$(ASAN_BUILD_DIR):
+$(DEBUG_ASAN_BUILD_DIR):
 	mkdir -p $@
 
-$(UBSAN_BUILD_DIR):
+$(RELEASE_ASAN_BUILD_DIR):
 	mkdir -p $@
 
-$(BUILD_DIR):
+$(DEBUG_UBSAN_BUILD_DIR):
+	mkdir -p $@
+
+$(RELEASE_UBSAN_BUILD_DIR):
+	mkdir -p $@
+
+$(TEST_BUILD_DIR):
+	mkdir -p $@
+
+$(BENCHMARK_BUILD_DIR):
 	mkdir -p $@
 
 $(GTEST_PARALLEL):
@@ -63,45 +87,63 @@ $(ASCON_INC_DIR): $(SHA3_INC_DIR)
 $(SUBTLE_INC_DIR): $(ASCON_INC_DIR)
 	git submodule update --init subtle
 
-$(BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
-	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(OPT_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+$(TEST_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(TEST_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
-$(ASAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(ASAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
-	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(ASAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+$(DEBUG_ASAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(DEBUG_ASAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(DEBUG_ASAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
-$(UBSAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(UBSAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
-	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(UBSAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+$(RELEASE_ASAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(RELEASE_ASAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_ASAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+
+$(DEBUG_UBSAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(DEBUG_UBSAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(DEBUG_UBSAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+
+$(RELEASE_UBSAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(RELEASE_UBSAN_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_UBSAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
 $(TEST_BINARY): $(TEST_OBJECTS)
-	$(CXX) $(OPT_FLAGS) $(LINK_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
 
-$(ASAN_TEST_BINARY): $(ASAN_TEST_OBJECTS)
-	$(CXX) $(ASAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+$(DEBUG_ASAN_TEST_BINARY): $(DEBUG_ASAN_TEST_OBJECTS)
+	$(CXX) $(DEBUG_ASAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
 
-$(UBSAN_TEST_BINARY): $(UBSAN_TEST_OBJECTS)
-	$(CXX) $(UBSAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+$(RELEASE_ASAN_TEST_BINARY): $(RELEASE_ASAN_TEST_OBJECTS)
+	$(CXX) $(RELEASE_ASAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+
+$(DEBUG_UBSAN_TEST_BINARY): $(DEBUG_UBSAN_TEST_OBJECTS)
+	$(CXX) $(DEBUG_UBSAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+
+$(RELEASE_UBSAN_TEST_BINARY): $(RELEASE_UBSAN_TEST_OBJECTS)
+	$(CXX) $(RELEASE_UBSAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
 
 test: $(TEST_BINARY) $(GTEST_PARALLEL)
 	$(GTEST_PARALLEL) $< --print_test_times
 
-asan_test: $(ASAN_TEST_BINARY) $(GTEST_PARALLEL)
+debug_asan_test: $(DEBUG_ASAN_TEST_BINARY) $(GTEST_PARALLEL)
 	$(GTEST_PARALLEL) $< --print_test_times
 
-ubsan_test: $(UBSAN_TEST_BINARY) $(GTEST_PARALLEL)
+release_asan_test: $(RELEASE_ASAN_TEST_BINARY) $(GTEST_PARALLEL)
 	$(GTEST_PARALLEL) $< --print_test_times
 
-$(BUILD_DIR)/%.o: $(BENCHMARK_DIR)/%.cpp $(BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
-	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(OPT_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
+debug_ubsan_test: $(DEBUG_UBSAN_TEST_BINARY) $(GTEST_PARALLEL)
+	$(GTEST_PARALLEL) $< --print_test_times
+
+release_ubsan_test: $(RELEASE_UBSAN_TEST_BINARY) $(GTEST_PARALLEL)
+	$(GTEST_PARALLEL) $< --print_test_times
+
+$(BENCHMARK_BUILD_DIR)/%.o: $(BENCHMARK_DIR)/%.cpp $(BENCHMARK_BUILD_DIR) $(SHA3_INC_DIR) $(ASCON_INC_DIR) $(SUBTLE_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
 $(BENCHMARK_BINARY): $(BENCHMARK_OBJECTS)
-	$(CXX) $(OPT_FLAGS) $(LINK_FLAGS) $^ $(BENCHMARK_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(BENCHMARK_LINK_FLAGS) -o $@
 
 benchmark: $(BENCHMARK_BINARY)
 	# Must *not* build google-benchmark with libPFM
 	./$< --benchmark_time_unit=ms --benchmark_min_warmup_time=.5 --benchmark_enable_random_interleaving=true --benchmark_repetitions=16 --benchmark_min_time=0.1s --benchmark_display_aggregates_only=true --benchmark_report_aggregates_only=true --benchmark_counters_tabular=true --benchmark_out_format=json --benchmark_out=$(BENCHMARK_OUT_FILE)
 
 $(PERF_BINARY): $(BENCHMARK_OBJECTS)
-	$(CXX) $(OPT_FLAGS) $(LINK_FLAGS) $^ $(PERF_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(PERF_LINK_FLAGS) -o $@
 
 perf: $(PERF_BINARY)
 	# Must build google-benchmark with libPFM, follow https://gist.github.com/itzmeanjan/05dc3e946f635d00c5e0b21aae6203a7

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,59 @@
 CXX ?= clang++
-CXX_FLAGS = -std=c++20
-WARN_FLAGS = -Wall -Wextra -Wpedantic
-DEBUG_FLAGS = -O1 -g
-RELEASE_FLAGS = -O3 -march=native
-LINK_FLAGS = -flto
-ASAN_FLAGS = -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address # From https://clang.llvm.org/docs/AddressSanitizer.html
-DEBUG_ASAN_FLAGS = $(DEBUG_FLAGS) $(ASAN_FLAGS)
-RELEASE_ASAN_FLAGS = -g $(RELEASE_FLAGS) $(ASAN_FLAGS)
-UBSAN_FLAGS = -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=undefined # From https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
-DEBUG_UBSAN_FLAGS = $(DEBUG_FLAGS) $(UBSAN_FLAGS)
-RELEASE_UBSAN_FLAGS = -g $(RELEASE_FLAGS) $(UBSAN_FLAGS)
+CXX_FLAGS := -std=c++20
+WARN_FLAGS := -Wall -Wextra -Wpedantic
+DEBUG_FLAGS := -O1 -g
+RELEASE_FLAGS := -O3 -march=native
+LINK_OPT_FLAGS := -flto
+ASAN_FLAGS := -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address # From https://clang.llvm.org/docs/AddressSanitizer.html
+DEBUG_ASAN_FLAGS := $(DEBUG_FLAGS) $(ASAN_FLAGS)
+RELEASE_ASAN_FLAGS := -g $(RELEASE_FLAGS) $(ASAN_FLAGS)
+UBSAN_FLAGS := -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=undefined # From https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+DEBUG_UBSAN_FLAGS := $(DEBUG_FLAGS) $(UBSAN_FLAGS)
+RELEASE_UBSAN_FLAGS := -g $(RELEASE_FLAGS) $(UBSAN_FLAGS)
 
-I_FLAGS = -I ./include
-SHA3_INC_DIR = ./sha3/include
-ASCON_INC_DIR = ./ascon/include
-SUBTLE_INC_DIR = ./subtle/include
-DEP_IFLAGS = -I $(SHA3_INC_DIR) -I $(ASCON_INC_DIR) -I $(SUBTLE_INC_DIR)
+I_FLAGS := -I ./include
+SHA3_INC_DIR := ./sha3/include
+ASCON_INC_DIR := ./ascon/include
+SUBTLE_INC_DIR := ./subtle/include
+DEP_IFLAGS := -I $(SHA3_INC_DIR) -I $(ASCON_INC_DIR) -I $(SUBTLE_INC_DIR)
 
-SRC_DIR = include
+SRC_DIR := include
 RACCOON_SOURCES := $(shell find $(SRC_DIR) -name '*.hpp')
-BUILD_DIR = build
-TEST_BUILD_DIR = $(BUILD_DIR)/test
-BENCHMARK_BUILD_DIR = $(BUILD_DIR)/benchmark
-ASAN_BUILD_DIR = $(BUILD_DIR)/asan
-DEBUG_ASAN_BUILD_DIR = $(ASAN_BUILD_DIR)/debug
-RELEASE_ASAN_BUILD_DIR = $(ASAN_BUILD_DIR)/release
-UBSAN_BUILD_DIR = $(BUILD_DIR)/ubsan
-DEBUG_UBSAN_BUILD_DIR = $(UBSAN_BUILD_DIR)/debug
-RELEASE_UBSAN_BUILD_DIR = $(UBSAN_BUILD_DIR)/release
+BUILD_DIR := build
+TEST_BUILD_DIR := $(BUILD_DIR)/test
+BENCHMARK_BUILD_DIR := $(BUILD_DIR)/benchmark
+ASAN_BUILD_DIR := $(BUILD_DIR)/asan
+DEBUG_ASAN_BUILD_DIR := $(ASAN_BUILD_DIR)/debug
+RELEASE_ASAN_BUILD_DIR := $(ASAN_BUILD_DIR)/release
+UBSAN_BUILD_DIR := $(BUILD_DIR)/ubsan
+DEBUG_UBSAN_BUILD_DIR := $(UBSAN_BUILD_DIR)/debug
+RELEASE_UBSAN_BUILD_DIR := $(UBSAN_BUILD_DIR)/release
 
-TEST_DIR = tests
+TEST_DIR := tests
 TEST_SOURCES := $(wildcard $(TEST_DIR)/*.cpp)
 TEST_HEADERS := $(wildcard $(TEST_DIR)/*.hpp)
 TEST_OBJECTS := $(addprefix $(TEST_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
-TEST_BINARY = $(TEST_BUILD_DIR)/test.out
-TEST_LINK_FLAGS = -lgtest -lgtest_main
-GTEST_PARALLEL = ./gtest-parallel/gtest-parallel
+TEST_BINARY := $(TEST_BUILD_DIR)/test.out
+TEST_LINK_FLAGS := -lgtest -lgtest_main
+GTEST_PARALLEL := ./gtest-parallel/gtest-parallel
 DEBUG_ASAN_TEST_OBJECTS := $(addprefix $(DEBUG_ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
 RELEASE_ASAN_TEST_OBJECTS := $(addprefix $(RELEASE_ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
-DEBUG_ASAN_TEST_BINARY = $(DEBUG_ASAN_BUILD_DIR)/test.out
-RELEASE_ASAN_TEST_BINARY = $(RELEASE_ASAN_BUILD_DIR)/test.out
+DEBUG_ASAN_TEST_BINARY := $(DEBUG_ASAN_BUILD_DIR)/test.out
+RELEASE_ASAN_TEST_BINARY := $(RELEASE_ASAN_BUILD_DIR)/test.out
 DEBUG_UBSAN_TEST_OBJECTS := $(addprefix $(DEBUG_UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
 RELEASE_UBSAN_TEST_OBJECTS := $(addprefix $(RELEASE_UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
-DEBUG_UBSAN_TEST_BINARY = $(DEBUG_UBSAN_BUILD_DIR)/test.out
-RELEASE_UBSAN_TEST_BINARY = $(RELEASE_UBSAN_BUILD_DIR)/test.out
+DEBUG_UBSAN_TEST_BINARY := $(DEBUG_UBSAN_BUILD_DIR)/test.out
+RELEASE_UBSAN_TEST_BINARY := $(RELEASE_UBSAN_BUILD_DIR)/test.out
 
-BENCHMARK_DIR = benchmarks
+BENCHMARK_DIR := benchmarks
 BENCHMARK_SOURCES := $(wildcard $(BENCHMARK_DIR)/*.cpp)
 BENCHMARK_HEADERS := $(wildcard $(BENCHMARK_DIR)/*.hpp)
 BENCHMARK_OBJECTS := $(addprefix $(BENCHMARK_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(BENCHMARK_SOURCES))))
-BENCHMARK_LINK_FLAGS = -lbenchmark -lbenchmark_main -lpthread
-BENCHMARK_BINARY = $(BENCHMARK_BUILD_DIR)/bench.out
-PERF_LINK_FLAGS = -lbenchmark -lbenchmark_main -lpfm -lpthread
-PERF_BINARY = $(BENCHMARK_BUILD_DIR)/perf.out
-BENCHMARK_OUT_FILE = bench_result_on_$(shell uname -s)_$(shell uname -r)_$(shell uname -m)_with_$(CXX)_$(shell $(CXX) -dumpversion).json
+BENCHMARK_LINK_FLAGS := -lbenchmark -lbenchmark_main -lpthread
+BENCHMARK_BINARY := $(BENCHMARK_BUILD_DIR)/bench.out
+PERF_LINK_FLAGS := -lbenchmark -lbenchmark_main -lpfm -lpthread
+PERF_BINARY := $(BENCHMARK_BUILD_DIR)/perf.out
+BENCHMARK_OUT_FILE := bench_result_on_$(shell uname -s)_$(shell uname -r)_$(shell uname -m)_with_$(CXX)_$(shell $(CXX) -dumpversion).json
 
 all: test
 
@@ -103,7 +103,7 @@ $(RELEASE_UBSAN_BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(RELEASE_UBSAN_BUILD_DIR) $(S
 	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_UBSAN_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
 $(TEST_BINARY): $(TEST_OBJECTS)
-	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_OPT_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
 
 $(DEBUG_ASAN_TEST_BINARY): $(DEBUG_ASAN_TEST_OBJECTS)
 	$(CXX) $(DEBUG_ASAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
@@ -136,14 +136,14 @@ $(BENCHMARK_BUILD_DIR)/%.o: $(BENCHMARK_DIR)/%.cpp $(BENCHMARK_BUILD_DIR) $(SHA3
 	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(RELEASE_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
 
 $(BENCHMARK_BINARY): $(BENCHMARK_OBJECTS)
-	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(BENCHMARK_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_OPT_FLAGS) $^ $(BENCHMARK_LINK_FLAGS) -o $@
 
 benchmark: $(BENCHMARK_BINARY)
 	# Must *not* build google-benchmark with libPFM
 	./$< --benchmark_time_unit=ms --benchmark_min_warmup_time=.5 --benchmark_enable_random_interleaving=true --benchmark_repetitions=16 --benchmark_min_time=0.1s --benchmark_display_aggregates_only=true --benchmark_report_aggregates_only=true --benchmark_counters_tabular=true --benchmark_out_format=json --benchmark_out=$(BENCHMARK_OUT_FILE)
 
 $(PERF_BINARY): $(BENCHMARK_OBJECTS)
-	$(CXX) $(RELEASE_FLAGS) $(LINK_FLAGS) $^ $(PERF_LINK_FLAGS) -o $@
+	$(CXX) $(RELEASE_FLAGS) $(LINK_OPT_FLAGS) $^ $(PERF_LINK_FLAGS) -o $@
 
 perf: $(PERF_BINARY)
 	# Must build google-benchmark with libPFM, follow https://gist.github.com/itzmeanjan/05dc3e946f635d00c5e0b21aae6203a7

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ cmake version 3.28.3
 For ensuring functional correctness of this Raccoon post-quantum digital signature scheme's library implemenation, issue
 
 ```bash
-make -j            # Run tests without any sort of sanitizers
-make asan_test -j  # Run tests with AddressSanitizer enabled
-make ubsan_test -j # Run tests with UndefinedBehaviourSanitizer enabled
+# You can switch to non-default compiler, by setting variable `CXX` i.e. invoke like `$ CXX=clang++ make -j`.
+#
+make -j                    # Run tests without any sort of sanitizers
+make debug_asan_test -j    # Run tests with AddressSanitizer enabled, with `-O1`
+make release_asan_test -j  # Run tests with AddressSanitizer enabled, with `-O3 -march=native`
+make debug_ubsan_test -j   # Run tests with UndefinedBehaviourSanitizer enabled, with `-O1`
+make release_ubsan_test -j # Run tests with UndefinedBehaviourSanitizer enabled, with `-O3 -march=native`
 ```
 
 ```bash


### PR DESCRIPTION
- [x] Run ASAN and UBSAN tests in both DEBUG and RELEASE mode.
- [x] Update Github actions script to run all combination of ASAN, UBSAN tests, with g++ and clang++.
